### PR TITLE
Event Controller TEST & DTO & Event Controller Fix

### DIFF
--- a/src/main/java/com/swa/escape/controller/EventController.java
+++ b/src/main/java/com/swa/escape/controller/EventController.java
@@ -2,6 +2,7 @@ package com.swa.escape.controller;
 
 
 import com.swa.escape.domain.Event;
+import com.swa.escape.dto.EventCreateRequest;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,8 +14,28 @@ import java.util.ArrayList;
 @RequestMapping("/api")
 public class EventController {
 
-    @PostMapping("/event/{id}")
-    public ResponseEntity<Event> createEvent(@RequestBody RequestBody requestBody) {
+    // Event 추가하는 API
+    @PostMapping("/event")
+    public ResponseEntity<Event> createEvent(@RequestBody EventCreateRequest eventRequest) {
+        Event event = Event.builder()
+                .longitude(eventRequest.getEvent_longitude())
+                .latitude(eventRequest.getEvent_longitude())
+                .build();
+        return ResponseEntity.ok(event);
+    }
+
+    @GetMapping("/event/{event_id}")
+    public ResponseEntity<Event> getEvent(@PathVariable int event_id) {
+        Event event = Event.builder()
+                .eventId(event_id)
+                .longitude(1.0F)
+                .latitude(1.0F)
+                .build();
+        return ResponseEntity.ok(event);
+    }
+
+    @PatchMapping("/event/{event_id}")
+    public ResponseEntity<Event> updateEvent(@PathVariable int event_id) {
         Event event = Event.builder()
                 .longitude(1.0F)
                 .latitude(1.0F)
@@ -22,26 +43,8 @@ public class EventController {
         return ResponseEntity.ok(event);
     }
 
-    @GetMapping("/event/{id}")
-    public ResponseEntity<Event> getEvent(@PathVariable int id) {
-        Event event = Event.builder()
-                .longitude(1.0F)
-                .latitude(1.0F)
-                .build();
-        return ResponseEntity.ok(event);
-    }
-
-    @PatchMapping("/event/{id}")
-    public ResponseEntity<Event> updateEvent(@PathVariable int id) {
-        Event event = Event.builder()
-                .longitude(1.0F)
-                .latitude(1.0F)
-                .build();
-        return ResponseEntity.ok(event);
-    }
-
-    @DeleteMapping("/event/{id}")
-    public ResponseEntity<Event> deleteEvent(@PathVariable int id) {
+    @DeleteMapping("/event/{event_id}")
+    public ResponseEntity<Event> deleteEvent(@PathVariable int event_id) {
         Event event = Event.builder()
                 .longitude(1.0F)
                 .latitude(1.0F)

--- a/src/main/java/com/swa/escape/dto/EventCreateRequest.java
+++ b/src/main/java/com/swa/escape/dto/EventCreateRequest.java
@@ -1,0 +1,2 @@
+package com.swa.escape.dto;public class EventCreateRequest {
+}

--- a/src/main/java/com/swa/escape/dto/EventCreateRequest.java
+++ b/src/main/java/com/swa/escape/dto/EventCreateRequest.java
@@ -1,2 +1,12 @@
-package com.swa.escape.dto;public class EventCreateRequest {
+package com.swa.escape.dto;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EventCreateRequest {
+    private float event_latitude;
+    private float event_longitude;
 }

--- a/src/test/java/com/swa/escape/controller/EventControllerTest.java
+++ b/src/test/java/com/swa/escape/controller/EventControllerTest.java
@@ -1,27 +1,22 @@
 package com.swa.escape.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.swa.escape.domain.Event;
 import com.swa.escape.dto.EventCreateRequest;
-import com.swa.escape.dto.ReportModifyRequest;
-import jakarta.persistence.AssociationOverride;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
-import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -40,25 +35,28 @@ public class EventControllerTest {
     @Test
     @DisplayName("CREATE EVENT")
 
-    void createEvent() throws IOException, Exception{
+    void createEvent() throws Exception{
 
+        // given
         EventCreateRequest eventCreateRequest = new EventCreateRequest();
         eventCreateRequest.setEvent_latitude(1.0F);
         eventCreateRequest.setEvent_longitude(1.0F);
-//        eventController
+
+        // when
         mockMvc.perform(
                     post("/api/event")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(eventCreateRequest)))
+        // then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.latitude").value(1.0F))
                 .andExpect(jsonPath("$.longitude").value(1.0F))
-                .andDo(MockMvcResultHandlers.print());
+                .andDo(print());
     }
 
     @Test
     @DisplayName("GET EVENT")
-    void getEvent() throws  Exception, IOException{
+    void getEvent() throws  Exception {
 
         // Given
         int event_id = 1;
@@ -70,15 +68,10 @@ public class EventControllerTest {
                 .andExpect(jsonPath("$.eventId").value(1))
                 .andExpect(jsonPath("$.latitude").value(1.0F))
                 .andExpect(jsonPath("$.longitude").value(1.0F))
-                .andDo(MockMvcResultHandlers.print());
+                .andDo(print());
     }
 
-    // 쓰지 않을 예정 -> Event를 수정하면 잘못된 정보가 갱신될 수도 있음.
-    //
-    //    @Test
-    //    void updateEvent() {
-    //
-    //    }
+
 
     @Test
     @DisplayName("DELETE EVENT")
@@ -93,6 +86,13 @@ public class EventControllerTest {
                 .andExpect(jsonPath("$.eventId").value(1))
                 .andExpect(jsonPath("$.latitude").value(1.0F))
                 .andExpect(jsonPath("$.longitude").value(1.0F))
-                .andDo(MockMvcResultHandlers.print());
+                .andDo(print());
     }
+
+    //    @Test
+    //    public void patchEventTest() throws Exception{
+    //        // given
+    //        int event_id = 1;
+    //
+    //    }
 }

--- a/src/test/java/com/swa/escape/controller/EventControllerTest.java
+++ b/src/test/java/com/swa/escape/controller/EventControllerTest.java
@@ -1,0 +1,98 @@
+package com.swa.escape.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swa.escape.domain.Event;
+import com.swa.escape.dto.EventCreateRequest;
+import com.swa.escape.dto.ReportModifyRequest;
+import jakarta.persistence.AssociationOverride;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(EventController.class)
+public class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("CREATE EVENT")
+
+    void createEvent() throws IOException, Exception{
+
+        EventCreateRequest eventCreateRequest = new EventCreateRequest();
+        eventCreateRequest.setEvent_latitude(1.0F);
+        eventCreateRequest.setEvent_longitude(1.0F);
+//        eventController
+        mockMvc.perform(
+                    post("/api/event")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(eventCreateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.latitude").value(1.0F))
+                .andExpect(jsonPath("$.longitude").value(1.0F))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("GET EVENT")
+    void getEvent() throws  Exception, IOException{
+
+        // Given
+        int event_id = 1;
+
+        // When
+        mockMvc.perform(get(("/api/event/" + event_id))).andExpect(status().isOk())
+
+                // THEN
+                .andExpect(jsonPath("$.eventId").value(1))
+                .andExpect(jsonPath("$.latitude").value(1.0F))
+                .andExpect(jsonPath("$.longitude").value(1.0F))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    // 쓰지 않을 예정 -> Event를 수정하면 잘못된 정보가 갱신될 수도 있음.
+    //
+    //    @Test
+    //    void updateEvent() {
+    //
+    //    }
+
+    @Test
+    @DisplayName("DELETE EVENT")
+    void deleteEvent() throws Exception {
+
+        // Given
+        int eventId = 1;
+
+        // When
+        mockMvc.perform(get(("/api/event/" + eventId))).andExpect(status().isOk())
+                // THEN
+                .andExpect(jsonPath("$.eventId").value(1))
+                .andExpect(jsonPath("$.latitude").value(1.0F))
+                .andExpect(jsonPath("$.longitude").value(1.0F))
+                .andDo(MockMvcResultHandlers.print());
+    }
+}


### PR DESCRIPTION
1. feat : DTO, eventControllerTest 생성

2. fix : 
    a) eventController Post 메소드에 DTO로 넣어주기 
    b) eventController Get 메소드 event_id builder 추가

3. discussion : 
    eventController Test에서 Patch, 즉 업데이트는 체크 안함.
    - 이벤트를 수정하는 것으로 잘못된 수정을 할 수도 있음. -> 잘못된 리포트 불러오는 오류 발생 가능
    - 이벤트를 한시간 단위로 어차피 지울 것. 
    - 나중에 고려해야 할 상황은 장난으로 신고 기준 개수를 넘기는 경우
      -> 그때 patch가 필요할 수도 있을 것. 그때 정책에 맞게 다시 설정해야 할 것 같습니다. 